### PR TITLE
[Chapter 2] 회원 도메인 구현

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/auth/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.sparta.paymentsystem.domain.auth.controller;
+
+import com.sparta.paymentsystem.domain.auth.dto.AuthResponse;
+import com.sparta.paymentsystem.domain.auth.dto.LoginRequest;
+import com.sparta.paymentsystem.domain.auth.dto.SignupRequest;
+import com.sparta.paymentsystem.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest request) {
+        authService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/auth/dto/AuthResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/auth/dto/AuthResponse.java
@@ -1,0 +1,13 @@
+package com.sparta.paymentsystem.domain.auth.dto;
+
+public record AuthResponse(
+        String token,
+        MemberInfo member
+) {
+    public record MemberInfo(
+            Long id,
+            String name,
+            String email,
+            String phoneNumber
+    ) {}
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,8 @@
+package com.sparta.paymentsystem.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일을 입력하세요") String email,
+        @NotBlank(message = "비밀번호를 입력하세요") String password
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/auth/dto/SignupRequest.java
@@ -1,0 +1,23 @@
+package com.sparta.paymentsystem.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @NotBlank(message = "이름을 입력하세요")
+        @Size(min = 2, max = 20, message = "이름은 2~20자여야 합니다")
+        String name,
+
+        @NotBlank(message = "이메일을 입력하세요")
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력하세요")
+        @Size(min = 4, max = 100, message = "비밀번호는 4자 이상이어야 합니다")
+        String password,
+
+        @NotBlank(message = "전화번호를 입력하세요")
+        @Size(max = 20, message = "전화번호는 20자 이내여야 합니다")
+        String phoneNumber
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/auth/service/AuthService.java
@@ -1,0 +1,51 @@
+package com.sparta.paymentsystem.domain.auth.service;
+
+import com.sparta.paymentsystem.global.jwt.JwtProvider;
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import com.sparta.paymentsystem.domain.auth.dto.AuthResponse;
+import com.sparta.paymentsystem.domain.auth.dto.LoginRequest;
+import com.sparta.paymentsystem.domain.auth.dto.SignupRequest;
+import com.sparta.paymentsystem.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public void signup(SignupRequest request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new RuntimeException("이미 존재하는 이메일입니다.");
+        }
+        Member member = new Member(
+                request.name(),
+                request.email(),
+                passwordEncoder.encode(request.password()),
+                request.phoneNumber()
+        );
+        memberRepository.save(member);
+    }
+
+    public AuthResponse login(LoginRequest request) {
+        Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(() -> new RuntimeException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+        if (!passwordEncoder.matches(request.password(), member.getPasswordHash())) {
+            throw new RuntimeException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+        String token = jwtProvider.createToken(member.getId(), member.getEmail());
+        return new AuthResponse(token, toMemberInfo(member));
+    }
+
+    private AuthResponse.MemberInfo toMemberInfo(Member member) {
+        return new AuthResponse.MemberInfo(member.getId(), member.getName(), member.getEmail(), member.getPhoneNumber());
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/member/controller/MemberController.java
@@ -1,0 +1,21 @@
+package com.sparta.paymentsystem.domain.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.sparta.paymentsystem.domain.member.dto.MemberResponse;
+import com.sparta.paymentsystem.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponse> me(@AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(memberService.getMe(memberId));
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/member/dto/MemberResponse.java
@@ -1,0 +1,11 @@
+package com.sparta.paymentsystem.domain.member.dto;
+
+import java.time.LocalDateTime;
+
+public record MemberResponse(
+        Long id,
+        String name,
+        String email,
+        String phoneNumber,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/member/entity/Member.java
@@ -1,0 +1,38 @@
+package com.sparta.paymentsystem.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+
+@Entity
+@Table(name = "members")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "phone_number", nullable = false, length = 20)
+    private String phoneNumber;
+
+    public Member(String name, String email, String passwordHash, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.phoneNumber = phoneNumber;
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.paymentsystem.domain.member.repository;
+
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/member/service/MemberService.java
@@ -1,0 +1,32 @@
+package com.sparta.paymentsystem.domain.member.service;
+
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import com.sparta.paymentsystem.domain.member.dto.MemberResponse;
+import com.sparta.paymentsystem.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberResponse getMe(Long memberId) {
+        Member member = findById(memberId);
+        return new MemberResponse(
+                member.getId(),
+                member.getName(),
+                member.getEmail(),
+                member.getPhoneNumber(),
+                member.getCreatedAt()
+        );
+    }
+
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/paymentsystem/global/config/SecurityConfig.java
@@ -1,18 +1,59 @@
 package com.sparta.paymentsystem.global.config;
 
+import com.sparta.paymentsystem.global.filter.JwtAuthFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static org.springframework.boot.security.autoconfigure.web.servlet.PathRequest.toStaticResources;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) {
-        return http
+        http
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-                .build();
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"code\":\"AUTH_001\",\"message\":\"인증이 필요합니다\"}");
+                        })
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/favicon.*").permitAll()
+                        .requestMatchers("/", "/login", "/signup", "/products/**", "/cart", "/orders/**", "/checkout").permitAll()
+                        .requestMatchers("/api/auth/**", "/api/products/**", "/api/webhooks/**", "/api/config/**").permitAll()
+                        .requestMatchers("/error").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
     }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
 }

--- a/src/main/java/com/sparta/paymentsystem/global/filter/JwtAuthFilter.java
+++ b/src/main/java/com/sparta/paymentsystem/global/filter/JwtAuthFilter.java
@@ -1,0 +1,42 @@
+package com.sparta.paymentsystem.global.filter;
+
+import com.sparta.paymentsystem.global.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            if (jwtProvider.validate(token)) {
+                Long memberId = jwtProvider.getMemberId(token);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(memberId, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/global/jwt/JwtProvider.java
+++ b/src/main/java/com/sparta/paymentsystem/global/jwt/JwtProvider.java
@@ -1,0 +1,62 @@
+package com.sparta.paymentsystem.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final SecretKey key;
+    private final long expiration;
+    private final JwtParser parser;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration}") long expiration) {
+        this.key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+        this.expiration = expiration;
+        this.parser = Jwts.parser()
+                .verifyWith(this.key)
+                .build();
+    }
+
+    public String createToken(Long memberId, String email) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(memberId.toString())
+                .claim("email", email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(key)
+                .compact();
+    }
+
+    public Long getMemberId(String token) {
+        return Long.parseLong(parseClaims(token).getSubject());
+    }
+
+    public boolean validate(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("JWT 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return parser
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,6 @@
+-- 회원 데이터 (비밀번호: "sparta1234" → BCrypt 해시)
+INSERT INTO members (name, email, password_hash, phone_number, created_at, updated_at) VALUES ('르탄이', 'sparta@nbcamp.com', '$2b$10$GPazGXUOf.Ek2M3YYbt4GuGluvmUlm9.dA6M7MVQca4CQ0/iufLP.', '010-1234-5678', NOW(), NOW());
+
 -- 상품 데이터
 INSERT INTO products (name, price, stock, description, created_at, updated_at) VALUES
 ('코튼 트윌 볼캡', 5000, 200, '데일리 필수템 코튼 트윌 볼캡. 가볍고 편안한 착용감으로 어떤 코디에도 포인트.', NOW(), NOW()),


### PR DESCRIPTION
**변경 사항**

- Member 엔티티 구현 (name, email UNIQUE, passwordHash, phoneNumber)
- MemberRepository 생성 (findByEmail, existsByEmail 커스텀 쿼리 메서드)
- JWT 인증 인프라 구현 (JwtProvider, JwtAuthFilter)
- SecurityConfig 구현 (CSRF 비활성화, STATELESS 세션, 인증 경로 설정)
- AuthService 구현 (회원가입: 중복검사→해싱→저장, 로그인: 비밀번호 대조→토큰 발급)
- MemberService 구현 (회원 조회)
- AuthController / MemberController 구현 (3개 API 엔드포인트)

**테스트**

- [ ]  수동 테스트 완료 (Postman / 브라우저)
    - `POST /api/auth/signup` → 201 Created
    - `POST /api/auth/signup` (중복 이메일) → 409 Conflict
    - `POST /api/auth/login` → 200 OK + JWT 토큰 반환
    - `POST /api/auth/login` (잘못된 비밀번호) → 401 Unauthorized
    - `GET /api/members/me` (Bearer 토큰 포함) → 200 OK + 회원 정보
    - `GET /api/members/me` (토큰 없음) → 401 Unauthorized
- [ ]  기존 기능 영향 없음 확인

**스크린샷**

(Postman 테스트 결과 캡처 첨부)

**관련 Issue**

- Closes #3
