### PR TITLE
[Chapter 2] 장바구니 도메인 구현

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/cart/controller/CartController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/controller/CartController.java
@@ -1,0 +1,51 @@
+package com.sparta.paymentsystem.domain.cart.controller;
+
+import com.sparta.paymentsystem.domain.cart.dto.AddCartRequest;
+import com.sparta.paymentsystem.domain.cart.dto.AddCartResponse;
+import com.sparta.paymentsystem.domain.cart.dto.CartItemResponse;
+import com.sparta.paymentsystem.domain.cart.dto.UpdateCartRequest;
+import com.sparta.paymentsystem.domain.cart.facade.CartFacade;
+import com.sparta.paymentsystem.domain.cart.service.CartService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/cart")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartFacade cartFacade;
+    private final CartService cartService;
+
+    @GetMapping("/items")
+    public ResponseEntity<List<CartItemResponse>> getItems(@AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(cartService.getCartItems(memberId));
+    }
+
+    @PostMapping("/items")
+    public ResponseEntity<AddCartResponse> addItem(@AuthenticationPrincipal Long memberId,
+                                                   @Valid @RequestBody AddCartRequest request) {
+        Long cartItemId = cartFacade.addItem(memberId, request);
+        return ResponseEntity.ok(new AddCartResponse(cartItemId));
+    }
+
+    @PatchMapping("/items/{id}")
+    public ResponseEntity<Void> updateQuantity(@AuthenticationPrincipal Long memberId,
+                                               @PathVariable Long id,
+                                               @Valid @RequestBody UpdateCartRequest request) {
+        cartService.updateQuantity(memberId, id, request.quantity());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/items/{itemId}")
+    public ResponseEntity<Void> removeItem(@AuthenticationPrincipal Long memberId,
+                                           @PathVariable Long itemId) {
+        cartService.removeItem(memberId, itemId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/dto/AddCartRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/dto/AddCartRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.paymentsystem.domain.cart.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record AddCartRequest(
+        @NotNull(message = "상품 ID는 필수입니다") Long productId,
+        @Min(value = 1, message = "수량은 1 이상이어야 합니다") int quantity
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/dto/AddCartResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/dto/AddCartResponse.java
@@ -1,0 +1,5 @@
+package com.sparta.paymentsystem.domain.cart.dto;
+
+public record AddCartResponse(
+        Long cartItemId
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/dto/CartItemResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/dto/CartItemResponse.java
@@ -1,0 +1,10 @@
+package com.sparta.paymentsystem.domain.cart.dto;
+
+public record CartItemResponse(
+        Long id,
+        Long productId,
+        String productName,
+        int price,
+        int quantity,
+        int stock
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/dto/UpdateCartRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/dto/UpdateCartRequest.java
@@ -1,0 +1,7 @@
+package com.sparta.paymentsystem.domain.cart.dto;
+
+import jakarta.validation.constraints.Min;
+
+public record UpdateCartRequest(
+        @Min(value = 1, message = "수량은 1 이상이어야 합니다") int quantity
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/entity/CartItem.java
@@ -1,0 +1,64 @@
+package com.sparta.paymentsystem.domain.cart.entity;
+
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import com.sparta.paymentsystem.domain.product.entity.Product;
+import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cart_items", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "product_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false, columnDefinition = "int UNSIGNED DEFAULT 1")
+    private int quantity;
+
+    public CartItem(Member member, Product product, int quantity) {
+        this.member = member;
+        this.product = product;
+        if (quantity < 1) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+        this.quantity = quantity;
+    }
+
+    public Long getMemberId() {
+        return member.getId();
+    }
+
+    public Long getProductId() {
+        return product.getId();
+    }
+
+    public void addQuantity(int quantity) {
+        if (quantity < 1) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+        this.quantity += quantity;
+    }
+
+    public void changeQuantity(int quantity) {
+        if (quantity < 1) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/facade/CartFacade.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/facade/CartFacade.java
@@ -1,0 +1,30 @@
+package com.sparta.paymentsystem.domain.cart.facade;
+
+import com.sparta.paymentsystem.domain.cart.dto.AddCartRequest;
+import com.sparta.paymentsystem.domain.cart.entity.CartItem;
+import com.sparta.paymentsystem.domain.cart.service.CartService;
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import com.sparta.paymentsystem.domain.member.service.MemberService;
+import com.sparta.paymentsystem.domain.product.entity.Product;
+import com.sparta.paymentsystem.domain.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CartFacade {
+
+    private final CartService cartService;
+    private final MemberService memberService;
+    private final ProductService productService;
+
+    @Transactional
+    public Long addItem(Long memberId, AddCartRequest request) {
+        Member member = memberService.findById(memberId);
+        Product product = productService.findProductEntity(request.productId());
+        CartItem cartItem = new CartItem(member, product, request.quantity());
+        return cartService.addItem(cartItem);
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/repository/CartItemRepository.java
@@ -1,0 +1,22 @@
+package com.sparta.paymentsystem.domain.cart.repository;
+
+import com.sparta.paymentsystem.domain.cart.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    @Query("SELECT ci FROM CartItem ci JOIN FETCH ci.product WHERE ci.member.id = :memberId")
+    List<CartItem> findByMemberId(@Param("memberId") Long memberId);
+
+    Optional<CartItem> findByMember_IdAndProduct_Id(Long memberId, Long productId);
+
+    @Modifying
+    @Query("DELETE FROM CartItem ci WHERE ci.id = :id AND ci.member.id = :memberId")
+    int deleteByIdAndMember_Id(@Param("id") Long id, @Param("memberId") Long memberId);
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
@@ -1,0 +1,66 @@
+package com.sparta.paymentsystem.domain.cart.service;
+
+import com.sparta.paymentsystem.domain.cart.entity.CartItem;
+import com.sparta.paymentsystem.domain.cart.dto.CartItemResponse;
+import com.sparta.paymentsystem.domain.cart.repository.CartItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartService {
+
+    private final CartItemRepository cartItemRepository;
+
+    public List<CartItemResponse> getCartItems(Long memberId) {
+        return cartItemRepository.findByMemberId(memberId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public Long addItem(CartItem cartItem) {
+        Optional<CartItem> existing = cartItemRepository.findByMember_IdAndProduct_Id(
+                cartItem.getMemberId(), cartItem.getProductId()
+        );
+        if (existing.isPresent()) {
+            CartItem found = existing.get();
+            found.addQuantity(cartItem.getQuantity());
+            return found.getId();
+        } else {
+            return cartItemRepository.save(cartItem).getId();
+        }
+    }
+
+    @Transactional
+    public void updateQuantity(Long memberId, Long itemId, int quantity) {
+        CartItem item = cartItemRepository.findById(itemId)
+                .filter(ci -> ci.getMemberId().equals(memberId))
+                .orElseThrow(() -> new RuntimeException("장바구니 항목을 찾을 수 없습니다."));
+        item.changeQuantity(quantity);
+    }
+
+    @Transactional
+    public void removeItem(Long memberId, Long itemId) {
+        int deleted = cartItemRepository.deleteByIdAndMember_Id(itemId, memberId);
+        if (deleted == 0) {
+            throw new RuntimeException("장바구니 항목을 찾을 수 없습니다.");
+        }
+    }
+
+    private CartItemResponse toResponse(CartItem item) {
+        return new CartItemResponse(
+                item.getId(),
+                item.getProduct().getId(),
+                item.getProduct().getName(),
+                item.getProduct().getPrice(),
+                item.getQuantity(),
+                item.getProduct().getStock()
+        );
+    }
+}

--- a/src/test/http/cart.http
+++ b/src/test/http/cart.http
@@ -1,0 +1,23 @@
+### 로그인 (토큰 발급)
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "sparta@nbcamp.com",
+  "password": "sparta1234"
+}
+
+> {% client.global.set("authToken", response.body.token); %}
+
+### TC-6. 수량 변경 (잘못된 값) — 기대: 400 Bad Request
+PATCH http://localhost:8080/api/cart/items/1
+Authorization: Bearer {{authToken}}
+Content-Type: application/json
+
+{
+  "quantity": 0
+}
+
+### TC-7. 존재하지 않는 항목 삭제 — 기대: 404 Not Found
+DELETE http://localhost:8080/api/cart/items/999
+Authorization: Bearer {{authToken}}


### PR DESCRIPTION
**변경 사항**

- CartItem 엔티티 구현 (Member/Product ManyToOne 관계, 복합 UNIQUE 제약, addQuantity/changeQuantity 비즈니스 메서드)
- CartItemRepository 생성 (findByMemberId, findByMember_IdAndProduct_Id, deleteByIdAndMember_Id)
- 요청/응답 DTO 구현 (AddCartRequest, UpdateCartRequest, CartItemResponse)
- CartService 구현 (장바구니 CRUD 4개, 중복 담기 시 수량 합산 로직)
- CartFacade 구현 (Member/Product 존재 검증 + CartService 위임)
- CartController 구현 (POST/GET/PATCH/DELETE 4개 엔드포인트)

**테스트**

- [ ]  수동 테스트 완료 (Postman / 브라우저)
    - `POST /api/cart/items` (신규 담기) → 200 OK + cartItemId
    - `POST /api/cart/items` (중복 담기) → 200 OK + 수량 합산
    - `GET /api/cart/items` → 200 OK + 장바구니 목록 (현재 가격 반영)
    - `PATCH /api/cart/items/{id}` (정상 수량) → 200 OK
    - `PATCH /api/cart/items/{id}` (수량 0) → 400 Bad Request
    - `DELETE /api/cart/items/{id}` → 200 OK
    - `DELETE /api/cart/items/999` → 404 Not Found
- [ ]  기존 기능 영향 없음 확인

**스크린샷**

(Postman 테스트 결과 캡처 첨부)

**관련 Issue**

- Closes #5
