### PR TITLE
[Chapter 3] 주문+결제 동시 생성

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/repository/CartItemRepository.java
@@ -20,9 +20,17 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     int deleteByIdAndMember_Id(@Param("id") Long id, @Param("memberId") Long memberId);
 
     // 주문서에 담을 선택된 장바구니 아이템을 상품 정보와 함께 조회
-    // - memberId 조건 : 다른 회원의 cartItemId를 넘겨도 조회되지 않도록 소유권 검증
-    // - JOIN FETCH : 주문서에서 상품명/가격을 써야 하므로 N+1 방지
+    // - memberId 조건 : 다른 회원의 cartItemId를 넘겨도 조회되지 않도록 고유권 검증
+    // - JOIN FETCH : 주문서에서 상품명/가격을 써야 하므로 n+1 방지
     @Query("SELECT ci FROM CartItem ci JOIN FETCH ci.product WHERE ci.id IN :ids AND ci.member.id = :memberId")
     List<CartItem> findByIdInAndMember_IdWithProduct(@Param("ids") List<Long> ids, @Param("memberId") Long memberId);
+
+    // 주문 생성 완료 직후 "주문한 장바구니 아이템만" 일괄 삭제
+    // - member.id 조건: 남의 cartItemId를 섞어 보내도 삭제되지 않게 하는 소유권 검증
+    // - IN절 일괄 삭제: 개별 deleteByIdAndMember_Id를 주문한 아이템 수만큼 반복 호출하는 대신 한 번의 쿼리로 처리 (N번 쿼리 → 1번)
+    // - 반환 int: 실제로 삭제된 행 수
+    @Modifying
+    @Query("DELETE FROM CartItem c WHERE c.id IN :ids AND c.member.id = :memberId")
+    int deleteAllByIdInAndMemberId(@Param("ids") List<Long> ids, @Param("memberId") Long memberId);
 
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
@@ -6,12 +6,14 @@ import com.sparta.paymentsystem.domain.cart.repository.CartItemRepository;
 import com.sparta.paymentsystem.global.error.BusinessException;
 import com.sparta.paymentsystem.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -42,7 +44,7 @@ public class CartService {
     @Transactional
     public void updateQuantity(Long memberId, Long itemId, int quantity) {
         CartItem item = cartItemRepository.findById(itemId)
-                .filter(ci -> ci.getMember().getId().equals(memberId))
+                .filter(ci -> ci.getMemberId().equals(memberId))
                 .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
         item.changeQuantity(quantity);
     }
@@ -63,6 +65,14 @@ public class CartService {
         return cartItemRepository.findByIdInAndMember_IdWithProduct(cartItemIds, memberId);
     }
 
+    public void clearCartItems(List<Long> orderedItemIds, Long memberId) {
+        int deleted = cartItemRepository.deleteAllByIdInAndMemberId(orderedItemIds, memberId);
+        if (deleted != orderedItemIds.size()) {
+            log.warn("장바구니 삭제 불일치: expected={}, actual={}, memberId={}",
+                    orderedItemIds.size(), deleted, memberId);
+        }
+    }
+
     private CartItemResponse toResponse(CartItem item) {
         return new CartItemResponse(
                 item.getId(),
@@ -73,4 +83,5 @@ public class CartService {
                 item.getProduct().getStock()
         );
     }
+
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/controller/OrderController.java
@@ -1,15 +1,16 @@
 package com.sparta.paymentsystem.domain.order.controller;
 
 import com.sparta.paymentsystem.domain.order.dto.CheckoutResponse;
+import com.sparta.paymentsystem.domain.order.dto.OrderCheckoutRequest;
+import com.sparta.paymentsystem.domain.order.dto.OrderCheckoutResponse;
+import com.sparta.paymentsystem.domain.order.dto.OrderResponse;
 import com.sparta.paymentsystem.domain.order.facade.OrderFacade;
 import com.sparta.paymentsystem.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,6 +27,25 @@ public class OrderController {
             @RequestParam(required = false) List<Long> cartItemIds
     ) {
         return ResponseEntity.ok(ApiResponse.ok(orderFacade.getCheckout(memberId, cartItemIds)));
+    }
+
+    @PostMapping("/checkout")
+    public ResponseEntity<ApiResponse<OrderCheckoutResponse>> createOrder(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody(required = false) OrderCheckoutRequest request) {
+        OrderCheckoutResponse response = orderFacade.createOrder(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getOrders(@AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(ApiResponse.ok(orderFacade.getOrders(memberId)));
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> getOrder(@AuthenticationPrincipal Long memberId,
+                                                               @PathVariable Long orderId) {
+        return ResponseEntity.ok(ApiResponse.ok(orderFacade.getOrder(memberId, orderId)));
     }
 
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderCheckoutRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderCheckoutRequest.java
@@ -1,0 +1,13 @@
+package com.sparta.paymentsystem.domain.order.dto;
+
+import java.util.List;
+
+public record OrderCheckoutRequest(
+        List<Long> cartItemIds
+) {
+    public OrderCheckoutRequest {
+        if (cartItemIds == null) {
+            cartItemIds = List.of();
+        }
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderCheckoutResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderCheckoutResponse.java
@@ -1,0 +1,9 @@
+package com.sparta.paymentsystem.domain.order.dto;
+
+public record OrderCheckoutResponse(
+        Long orderId,
+        String portonePaymentId,
+        int totalPrice,
+        String orderName,
+        String status
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderItemResponse.java
@@ -1,0 +1,7 @@
+package com.sparta.paymentsystem.domain.order.dto;
+
+public record OrderItemResponse(
+        String productName,
+        int orderPrice,
+        int quantity
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/dto/OrderResponse.java
@@ -1,0 +1,14 @@
+package com.sparta.paymentsystem.domain.order.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderResponse(
+        Long orderId,
+        Long paymentId,
+        int totalPrice,
+        String status,
+        String orderName,
+        LocalDateTime createdAt,
+        List<OrderItemResponse> orderItems
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/entity/Order.java
@@ -1,0 +1,59 @@
+package com.sparta.paymentsystem.domain.order.entity;
+
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "total_price", nullable = false, columnDefinition = "int UNSIGNED")
+    private int totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderStatus status = OrderStatus.PENDING_PAYMENT;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    public Order(Member member, int totalPrice, List<OrderItem> orderItems) {
+        this.member = member;
+        this.totalPrice = totalPrice;
+        orderItems.forEach(this::addOrderItem);
+    }
+
+    public Long getMemberId() {
+        return member.getId();
+    }
+
+    public void addOrderItem(OrderItem orderItem) {
+        this.orderItems.add(orderItem);
+        orderItem.setOrder(this);
+    }
+
+    public String getOrderName() {
+        if (orderItems.isEmpty()) return "주문";
+        String firstName = orderItems.get(0).getProductName();
+        if (orderItems.size() == 1) return firstName;
+        return firstName + " 외 " + (orderItems.size() - 1) + "건";
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/entity/OrderItem.java
@@ -1,0 +1,52 @@
+package com.sparta.paymentsystem.domain.order.entity;
+
+import com.sparta.paymentsystem.domain.product.entity.Product;
+import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "product_name", nullable = false, length = 200)
+    private String productName;
+
+    @Column(name = "order_price", nullable = false, columnDefinition = "int UNSIGNED")
+    private int orderPrice;
+
+    @Column(nullable = false, columnDefinition = "int UNSIGNED")
+    private int quantity;
+
+    public OrderItem(Product product, int orderPrice, int quantity) {
+        this.product = product;
+        this.productName = product.getName();
+        this.orderPrice = orderPrice;
+        this.quantity = quantity;
+    }
+
+    void setOrder(Order order) {
+        this.order = order;
+    }
+
+    public int getSubtotal() {
+        return orderPrice * quantity;
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/entity/OrderStatus.java
@@ -1,0 +1,30 @@
+package com.sparta.paymentsystem.domain.order.entity;
+
+/**
+ * 주문 상태 머신
+ * - PENDING_PAYMENT → CONFIRMED: 결제 성공 → 주문 확정
+ * - PENDING_PAYMENT → CANCELLED: 결제 실패 또는 취소
+ * - CONFIRMED → CANCELLED: 결제 취소·환불
+ */
+public enum OrderStatus {
+    PENDING_PAYMENT {
+        @Override
+        public boolean canTransitTo(OrderStatus target) {
+            return target == CONFIRMED || target == CANCELLED;
+        }
+    },
+    CONFIRMED {
+        @Override
+        public boolean canTransitTo(OrderStatus target) {
+            return target == CANCELLED;
+        }
+    },
+    CANCELLED {
+        @Override
+        public boolean canTransitTo(OrderStatus target) {
+            return false;
+        }
+    };
+
+    public abstract boolean canTransitTo(OrderStatus target);
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/facade/OrderFacade.java
@@ -1,29 +1,45 @@
 package com.sparta.paymentsystem.domain.order.facade;
 
 import com.sparta.paymentsystem.domain.cart.entity.CartItem;
+import com.sparta.paymentsystem.domain.cart.facade.CartFacade;
 import com.sparta.paymentsystem.domain.cart.service.CartService;
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import com.sparta.paymentsystem.domain.member.service.MemberService;
 import com.sparta.paymentsystem.domain.order.dto.CheckoutResponse;
+import com.sparta.paymentsystem.domain.order.dto.OrderCheckoutRequest;
+import com.sparta.paymentsystem.domain.order.dto.OrderCheckoutResponse;
+import com.sparta.paymentsystem.domain.order.dto.OrderResponse;
+import com.sparta.paymentsystem.domain.order.entity.Order;
+import com.sparta.paymentsystem.domain.order.entity.OrderItem;
+import com.sparta.paymentsystem.domain.order.service.OrderService;
+import com.sparta.paymentsystem.domain.payment.entity.Payment;
+import com.sparta.paymentsystem.domain.payment.entity.PaymentStatus;
+import com.sparta.paymentsystem.domain.payment.service.PaymentService;
+import com.sparta.paymentsystem.domain.product.entity.Product;
 import com.sparta.paymentsystem.global.error.BusinessException;
 import com.sparta.paymentsystem.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 @Transactional(readOnly = true)
 public class OrderFacade {
 
     private final CartService cartService;
+    private final MemberService memberService;
+    private final OrderService orderService;
+    private final PaymentService paymentService;
 
     public CheckoutResponse getCheckout(Long memberId, List<Long> cartItemIds) {
-        // 주문서 미리보기 : 재고 차감/주문 생성 없는 읽기 전용
+        // 주문서 미리보기: 재고 차감/주문 생성 없는 읽기 전용
         // cartItemIds가 null/비어있으면 "전체 장바구니", 값이 있으면 "선택된 아이템만" 주문서에 담는다.
-        List<CartItem> cartItems = getValidatedCartItems(
+        List<CartItem> cartItems = getValidateCartItems(
                 memberId, cartItemIds != null ? cartItemIds : List.of()
         );
 
@@ -51,7 +67,74 @@ public class OrderFacade {
         return new CheckoutResponse(items, totalPrice);
     }
 
-    private List<CartItem> getValidatedCartItems(Long memberId, List<Long> cartItemIds) {
+    @Transactional
+    public OrderCheckoutResponse createOrder(Long memberId, OrderCheckoutRequest request) {
+        List<Long> cartItemIds = (request != null) ? request.cartItemIds() : List.of();
+
+        // 0. 회원 조회
+        Member member = memberService.findById(memberId);
+
+        // 1. 장바구니 조회 (선택된 아이템만)
+        List<CartItem> cartItems = getValidateCartItems(memberId, cartItemIds);
+
+        // 2~3. 재고 차감 + 스냅샷 OrderItem 생성
+        List<OrderItem> orderItems = new ArrayList<>();
+
+        for (CartItem cartItem : cartItems) {
+            Product product = cartItem.getProduct();
+            product.deductStock(cartItem.getQuantity());
+
+            OrderItem orderItem = new OrderItem(
+                    product,
+                    product.getPrice(),
+                    cartItem.getQuantity()
+            );
+            orderItems.add(orderItem);
+        }
+        int totalPrice = orderItems.stream().mapToInt(OrderItem::getSubtotal).sum();
+
+        // 4. 주문 저장
+        Order order = orderService.createOrder(member, orderItems, totalPrice);
+
+        // 5. 결제 정보 생성 (IN_PROGRESS 상태)
+        Payment payment = paymentService.createPayment(order, order.getTotalPrice());
+
+        // 6. 주문한 장바구니 아이템만 삭제
+        List<Long> orderedItemIds = cartItems.stream().map(CartItem::getId).toList();
+        cartService.clearCartItems(orderedItemIds, memberId);
+
+        // 7. 응답
+        return new OrderCheckoutResponse(
+                order.getId(),
+                payment.getPortonePaymentId(),
+                totalPrice,
+                order.getOrderName(),
+                order.getStatus().name()
+        );
+    }
+
+    public List<OrderResponse> getOrders(Long memberId) {
+        List<Order> orders = orderService.findOrderEntities(memberId);
+        List<Long> orderIds = orders.stream().map(Order::getId).toList();
+        Map<Long, Long> paymentMap = paymentService.findPaymentIdMapByOrderIds(orderIds);
+
+        return orders.stream()
+                .map(order -> orderService.toResponse(order, paymentMap.get(order.getId())))
+                .toList();
+    }
+
+    public OrderResponse getOrder(Long memberId, Long orderId) {
+        Order order = orderService.findOrderEntity(orderId);
+        if (!order.getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
+        }
+        Long paymentId = paymentService.findPaymentIdByOrderId(orderId).orElseThrow(
+                () -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)
+        );
+        return orderService.toResponse(order, paymentId);
+    }
+
+    private List<CartItem> getValidateCartItems(Long memberId, List<Long> cartItemIds) {
         // cartItemIds가 비어있으면 "전체 장바구니", 아니면 "선택된 아이템만" 조회
         List<CartItem> cartItems = cartItemIds.isEmpty()
                 ? cartService.findCartEntities(memberId)
@@ -68,6 +151,7 @@ public class OrderFacade {
         if (!cartItemIds.isEmpty() && cartItems.size() != cartItemIds.size()) {
             throw new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND);
         }
+
         return cartItems;
     }
 

--- a/src/main/java/com/sparta/paymentsystem/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/repository/OrderRepository.java
@@ -1,0 +1,27 @@
+package com.sparta.paymentsystem.domain.order.repository;
+
+import com.sparta.paymentsystem.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    // 내 주문 목록 조회 (최신순)
+    // - LEFT JOIN FETCH orderItems: 목록 카드에 "상품명 외 N건" 등을 표시해야 하므로 N+1 방지용
+    // - DISTINCT : 컬렉션 fetch join은 root(Order)가 orderItem 수만큼 중복 엔티티 제거
+    // - LEFT JOIN : 아이템이 하나도 없는 주문이 있더라도 목록에서 누락되지 않도록
+    @Query("SELECT DISTINCT o FROM Order o LEFT JOIN FETCH o.orderItems WHERE o.member.id = :memberId ORDER BY o.createdAt DESC")
+    List<Order> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") Long memberId);
+
+    // 주문 단건 상세 조회 : orderId만으로 조회
+    // - LEFT JOIN FETCH orderItems: 목록 카드에 "상품명 외 N건" 등을 표시해야 하므로 N+1 방지용
+    // - DISTINCT : 컬렉션 fetch join은 root(Order)가 orderItem 수만큼 중복 엔티티 제거
+    // - LEFT JOIN : 아이템이 하나도 없는 주문이 있더라도 목록에서 누락되지 않도록
+    @Query("SELECT DISTINCT o FROM Order o LEFT JOIN FETCH o.orderItems WHERE o.id = :orderId")
+    Optional<Order> findByIdWithOrderItems(@Param("orderId") Long orderId);
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/service/OrderService.java
@@ -1,0 +1,58 @@
+package com.sparta.paymentsystem.domain.order.service;
+
+import com.sparta.paymentsystem.domain.member.entity.Member;
+import com.sparta.paymentsystem.domain.order.dto.OrderItemResponse;
+import com.sparta.paymentsystem.domain.order.dto.OrderResponse;
+import com.sparta.paymentsystem.domain.order.entity.Order;
+import com.sparta.paymentsystem.domain.order.entity.OrderItem;
+import com.sparta.paymentsystem.domain.order.repository.OrderRepository;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    // 주문 생성
+    @Transactional
+    public Order createOrder(Member member, List<OrderItem> orderItems, int totalPrice) {
+        Order order = new Order(member, totalPrice, orderItems);
+        return orderRepository.save(order);
+    }
+
+    // 내 주문 목록 조회 (최신순)
+    public List<Order> findOrderEntities(Long memberId) {
+        return orderRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+    }
+
+    // 주문 단건 상세 조회 : orderId만으로 조회
+    public Order findOrderEntity(Long orderId) {
+        return orderRepository.findByIdWithOrderItems(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+    }
+
+    // Order -> OrderResponse 변환, OrderItem -> OrderItemResponse 변환
+    public OrderResponse toResponse(Order order, Long paymentId) {
+        List<OrderItemResponse> items = order.getOrderItems().stream()
+                .map(oi -> new OrderItemResponse(oi.getProductName(), oi.getOrderPrice(), oi.getQuantity()))
+                .toList();
+        return new OrderResponse(
+                order.getId(),
+                paymentId,
+                order.getTotalPrice(),
+                order.getStatus().name(),
+                order.getOrderName(),
+                order.getCreatedAt(),
+                items
+        );
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Payment.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Payment.java
@@ -1,0 +1,50 @@
+package com.sparta.paymentsystem.domain.payment.entity;
+
+import com.sparta.paymentsystem.domain.order.entity.Order;
+import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false, unique = true)
+    private Order order;
+
+    @Column(name = "portone_payment_id", nullable = false, unique = true, length = 200)
+    private String portonePaymentId;
+
+    @Column(nullable = false, columnDefinition = "int UNSIGNED")
+    private int amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentStatus status = PaymentStatus.IN_PROGRESS;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    public Payment(Order order, int amount) {
+        this.order = order;
+        this.amount = amount;
+        this.portonePaymentId = generatePortonePaymentId();
+    }
+
+    private static String generatePortonePaymentId() {
+        return "pay_" + UUID.randomUUID();
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,39 @@
+package com.sparta.paymentsystem.domain.payment.entity;
+
+/**
+ * 결제 상태 머신
+ * - IN_PROGRESS → PAID     : 결제 성공
+ * - IN_PROGRESS → FAILED   : 결제 미완료 (PG 실패, 금액 불일치 등)
+ * - PAID        → CANCELLED: 성공한 결제의 사후 취소 (환불)
+ *
+ * - FAILED  = 결제가 성공적으로 완료되지 못한 모든 경우
+ * - CANCELLED = 성공한 결제를 사후에 취소한 경우
+ */
+public enum PaymentStatus {
+    IN_PROGRESS {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return target == PAID || target == FAILED;
+        }
+    },
+    PAID {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return target == CANCELLED;
+        }
+    },
+    FAILED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return false;
+        }
+    },
+    CANCELLED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return false;
+        }
+    };
+
+    public abstract boolean canTransitTo(PaymentStatus target);
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,26 @@
+package com.sparta.paymentsystem.domain.payment.repository;
+
+import com.sparta.paymentsystem.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    // 주문 단건 조회 화면에서 결제 ID 한 건만 필요하므로 Payment 엔티티 전체를 로딩하지 않고 ID만 프로젝션
+    // Order ← Payment가 단방향 관계(Order가 Payment를 참조하지 않음)라서,
+    // 주문에 결제 ID를 붙이려면 이렇게 Payment 쪽에서 역으로 찾아야 한다.
+    @Query("SELECT p.id FROM Payment p WHERE p.order.id = :orderId")
+    Optional<Long> findIdByOrderId(@Param("orderId") Long orderId);
+
+    // 주문 "목록" 조회용 N+1 방지 일괄 조회
+    // 각 주문마다 findIdByOrderId를 돌리면 N번 쿼리가 나가는데, IN 절로 한 번에 가져와
+    // 서비스 레이어에서 Map<OrderId, PaymentId>로 재구성!
+    // 반환이 List<Object[]>인 이유: [orderId, paymentId] 쌍을 내려받기 위한 JPA 튜플 프로젝션
+    // 타입 안전성은 떨어지므로, 실무에선 인터페이스/레코드 프로젝션으로 개선 가능
+    @Query("SELECT p.order.id, p.id FROM Payment p WHERE p.order.id IN :orderIds")
+    List<Object[]> findIdsByOrderIds(@Param("orderIds") List<Long> orderIds);
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
@@ -1,0 +1,46 @@
+package com.sparta.paymentsystem.domain.payment.service;
+
+import com.sparta.paymentsystem.domain.order.entity.Order;
+import com.sparta.paymentsystem.domain.payment.entity.Payment;
+import com.sparta.paymentsystem.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    // 결제 생성
+    @Transactional
+    public Payment createPayment(Order order, int amount) {
+        Payment payment = new Payment(order, amount);
+        return paymentRepository.save(payment);
+    }
+
+    // 주문 단건 조회 화면에서 결제 ID 조회
+    public Optional<Long> findPaymentIdByOrderId(Long orderId) {
+        return paymentRepository.findIdByOrderId(orderId);
+    }
+
+    // 주문 목록에 결제 ID를 붙이기 위한 "Order → Payment" 조회
+    public Map<Long, Long> findPaymentIdMapByOrderIds(List<Long> orderIds) {
+        //  IN () 쿼리가 DB로 나가는 걸 차단하고 조기 반환
+        if (orderIds.isEmpty()) return Map.of();
+        // Repository의 [orderId, paymentId] 튜플(Object[])을 Map<OrderId, PaymentId>로 재구성
+        return paymentRepository.findIdsByOrderIds(orderIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/product/entity/Product.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/product/entity/Product.java
@@ -43,4 +43,14 @@ public class Product extends BaseTimeEntity {
         this.description = description;
     }
 
+    public void deductStock(int quantity) {
+        if (quantity <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_QUANTITY);
+        }
+        if (quantity > this.stock) {
+            throw new BusinessException(ErrorCode.INSUFFICIENT_STOCK);
+        }
+        this.stock -= quantity;
+    }
+
 }

--- a/src/test/http/order-checkout.http
+++ b/src/test/http/order-checkout.http
@@ -1,0 +1,167 @@
+### 사전 준비: 로그인 (토큰 발급)
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "sparta@nbcamp.com",
+  "password": "sparta1234"
+}
+
+> {%
+    client.global.set("token", response.body.data.token);
+%}
+
+###
+
+### 사전 준비: 장바구니에 상품 담기
+POST http://localhost:8080/api/cart/items
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "productId": 1,
+  "quantity": 1
+}
+
+###
+
+### TC-1. 주문+결제 동시 생성 (정상)
+# 기대: 201 Created + orderId, portonePaymentId, totalPrice, orderName, status 반환
+# 검증: 재고 차감 확인, 장바구니 비워짐 확인
+POST http://localhost:8080/api/orders/checkout
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "cartItemIds": [1]
+}
+
+> {%
+    client.test("응답 코드 201", function () {
+        client.assert(response.status === 201, "Expected 201 Created");
+    });
+    client.test("orderId 존재", function () {
+        client.assert(response.body.data.orderId != null, "orderId should not be null");
+    });
+    client.test("portonePaymentId 존재", function () {
+        client.assert(response.body.data.portonePaymentId != null, "portonePaymentId should not be null");
+    });
+    client.test("totalPrice 존재", function () {
+        client.assert(response.body.data.totalPrice > 0, "totalPrice should be greater than 0");
+    });
+    client.test("orderName 존재", function () {
+        client.assert(response.body.data.orderName != null, "orderName should not be null");
+    });
+    client.test("status 존재", function () {
+        client.assert(response.body.data.status != null, "status should not be null");
+    });
+%}
+
+###
+
+### TC-1 검증: 장바구니 비워짐 확인
+GET http://localhost:8080/api/cart/items
+Authorization: Bearer {{token}}
+
+> {%
+    client.test("장바구니 비어있음", function () {
+        client.assert(response.body.data.length === 0, "Cart should be empty after checkout");
+    });
+%}
+
+###
+
+### TC-2. 장바구니가 비어 있을 때
+# 기대: 400 Bad Request + 에러 응답
+POST http://localhost:8080/api/orders/checkout
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "cartItemIds": []
+}
+
+> {%
+    client.test("응답 코드 400", function () {
+        client.assert(response.status === 400, "Expected 400 Bad Request");
+    });
+%}
+
+###
+
+### TC-3 사전 준비: 재고 부족 테스트용 장바구니 담기 (재고보다 많은 수량)
+POST http://localhost:8080/api/cart/items
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "productId": 1,
+  "quantity": 99999
+}
+
+###
+
+### TC-3. 재고 부족
+# 기대: 409 Conflict + 에러 응답, 재고 원복 확인
+POST http://localhost:8080/api/orders/checkout
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "cartItemIds": [2]
+}
+
+> {%
+    client.test("응답 코드 409", function () {
+        client.assert(response.status === 409, "Expected 409 Conflict");
+    });
+%}
+
+###
+
+### TC-4. 주문 목록 조회
+# 기대: 200 OK + 주문 배열 (최신순 정렬)
+GET http://localhost:8080/api/orders
+Authorization: Bearer {{token}}
+
+> {%
+    client.test("응답 코드 200", function () {
+        client.assert(response.status === 200, "Expected 200 OK");
+    });
+    client.test("주문 목록이 배열", function () {
+        client.assert(Array.isArray(response.body.data), "data should be an array");
+    });
+%}
+
+###
+
+### TC-5. 주문 상세 조회 (정상)
+# 기대: 200 OK + 주문 상세 (items 포함)
+GET http://localhost:8080/api/orders/1
+Authorization: Bearer {{token}}
+
+> {%
+    client.test("응답 코드 200", function () {
+        client.assert(response.status === 200, "Expected 200 OK");
+    });
+    client.test("orderId 일치", function () {
+        client.assert(response.body.data.orderId === 1, "orderId should be 1");
+    });
+    client.test("items 존재", function () {
+        client.assert(response.body.data.orderItems != null, "orderItems should not be null");
+        client.assert(response.body.data.orderItems.length > 0, "orderItems should not be empty");
+    });
+%}
+
+###
+
+### TC-6. 주문 상세 조회 (존재하지 않는 ID)
+# 기대: 404 Not Found + 에러 응답
+GET http://localhost:8080/api/orders/999
+Authorization: Bearer {{token}}
+
+> {%
+    client.test("응답 코드 404", function () {
+        client.assert(response.status === 404, "Expected 404 Not Found");
+    });
+%}


### PR DESCRIPTION
**변경 사항**

- OrderStatus/PaymentStatus 상태 머신 enum 구현 (canTransitTo 전이 규칙)
- Order 엔티티 구현 (memberId, totalPrice, status, OrderItem 양방향 연관관계)
- OrderItem 엔티티 구현 (orderPrice 스냅샷 필드, cascade ALL + orphanRemoval)
- Payment 엔티티 구현 (orderId UNIQUE, portonePaymentId, 초기 상태 IN_PROGRESS)
- OrderRepository/PaymentRepository 생성
- CartService.clearCartItems() 장바구니 선택 삭제 메서드 추가
- Product.deductStock() 재고 차감 메서드 추가
- OrderFacade.createOrder() 트랜잭션 구현
- OrderService/PaymentService 구현
- OrderController (POST /api/orders/checkout, GET /api/orders, GET /api/orders/{orderId}) 구현

**테스트**

- [ ]  수동 테스트 완료 (Postman / 브라우저)
    - `POST /api/orders/checkout` (정상) → 201 Created
    - `POST /api/orders/checkout` (장바구니 비어있을 때) → 400 Bad Request
    - `POST /api/orders/checkout` (재고 부족) → 409 + 재고 원복 확인
    - `GET /api/orders` → 200 OK + 주문 목록 (최신순)
    - `GET /api/orders/{orderId}` → 200 OK + 주문 상세 (items 포함)
    - `GET /api/orders/999` → 404 Not Found
- [ ]  기존 기능 영향 없음 확인

**스크린샷**

(Postman 테스트 결과 캡처 첨부)

**관련 Issue**

- Closes #11