### PR TITLE
[Chapter 5] 결제 취소(환불) 기능 구현

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/controller/PaymentController.java
@@ -1,5 +1,7 @@
 package com.sparta.paymentsystem.domain.payment.controller;
 
+import com.sparta.paymentsystem.domain.payment.dto.PaymentCancelRequest;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentCancelResponse;
 import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmRequest;
 import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmResponse;
 import com.sparta.paymentsystem.domain.payment.facade.PaymentFacade;
@@ -8,10 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -25,5 +24,13 @@ public class PaymentController {
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody PaymentConfirmRequest request) {
         return ResponseEntity.ok(ApiResponse.ok(paymentFacade.confirmPayment(memberId, request)));
+    }
+
+    @PostMapping("/{id}/cancel")
+    public ResponseEntity<ApiResponse<PaymentCancelResponse>> cancelPayment(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long id,
+            @Valid @RequestBody(required = false) PaymentCancelRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(paymentFacade.cancelPayment(memberId, id, request)));
     }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentCancelRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentCancelRequest.java
@@ -1,0 +1,8 @@
+package com.sparta.paymentsystem.domain.payment.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record PaymentCancelRequest(
+        @Size(max = 500, message = "취소 사유는 500자 이내여야 합니다")
+        String reason
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentCancelResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentCancelResponse.java
@@ -1,0 +1,10 @@
+package com.sparta.paymentsystem.domain.payment.dto;
+
+public record PaymentCancelResponse(
+        Long paymentId,
+        Long orderId,
+        String portonePaymentId,
+        String paymentStatus,
+        String orderStatus,
+        String message
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Payment.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Payment.java
@@ -58,6 +58,10 @@ public class Payment extends BaseTimeEntity {
         changeStatus(PaymentStatus.FAILED);
     }
 
+    public void markAsCancelled() {
+        changeStatus(PaymentStatus.CANCELLED);
+    }
+
     // 결제 상태 변경 로직
     private void changeStatus(PaymentStatus newStatus) {
         if (!this.status.canTransitTo(newStatus)) {

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Refund.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Refund.java
@@ -1,0 +1,36 @@
+package com.sparta.paymentsystem.domain.payment.entity;
+
+import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refunds")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Refund extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id", nullable = false, unique = true)
+    private Payment payment;
+
+    @Column(nullable = false, length = 500)
+    private String reason;
+
+    @Column(name = "refunded_at", nullable = false)
+    private LocalDateTime refundedAt;
+
+    public Refund(Payment payment, String reason, LocalDateTime refundedAt) {
+        this.payment = payment;
+        this.reason = reason;
+        this.refundedAt = refundedAt;
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/facade/PaymentFacade.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/facade/PaymentFacade.java
@@ -1,6 +1,8 @@
 package com.sparta.paymentsystem.domain.payment.facade;
 
 import com.sparta.paymentsystem.domain.order.entity.Order;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentCancelRequest;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentCancelResponse;
 import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmRequest;
 import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmResponse;
 import com.sparta.paymentsystem.domain.payment.entity.Payment;
@@ -115,4 +117,38 @@ public class PaymentFacade {
         return paymentCommandService.approvePaymentAndOrder(order.getId());
     }
 
+    /**
+     * 결제 취소 (전액 취소)
+     *
+     * 1. 결제 조회 + 본인 검증 + 상태 선검증 (PAID)
+     * 2. [트랜잭션] DB 상태 변경 (CANCELLED) + 재고 원복 + Refund 생성
+     * 3. [외부 API] PG사 결제 취소 (DB 커밋 후, 실패 시 로그 + 수동 처리)
+     */
+    public PaymentCancelResponse cancelPayment(Long memberId, Long paymentId, PaymentCancelRequest request) {
+        String cancelReason = (request != null && request.reason() != null)
+                ? request.reason() : "사용자 요청 취소";
+
+        // 1. 결제 조회 + 본인 검증
+        Payment payment = paymentService.findByIdWithOrder(paymentId);
+        if (!payment.getOrder().getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
+        }
+
+        // 1-1. PAID 상태만 취소 가능 (불필요한 트랜잭션 + PG 호출 방지)
+        if (payment.getStatus() != PaymentStatus.PAID) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_STATUS);
+        }
+
+        // 2. 트랜잭션: DB 상태 변경 + 재고 원복 + Refund 생성
+        PaymentCancelResponse response = paymentCommandService.cancelPaymentAndOrder(paymentId, cancelReason);
+
+        // 3. 외부 API: PG사 결제 취소 (DB 커밋 후)
+        try {
+            paymentGateway.cancelPayment(response.portonePaymentId(), cancelReason);
+        } catch (Exception e) {
+            log.error("PG 결제 취소 실패 : DB는 이미 CANCELLED 커밋됨, 수동 처리 필요: portonePaymentId={}", response.portonePaymentId(), e);
+        }
+
+        return response;
+    }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
@@ -26,4 +26,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     // 주문 단건 상세 조회 : orderId만으로 조회
     @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.order.id = :orderId")
     Optional<Payment> findByOrderIdWithOrder(@Param("orderId") Long orderId);
+
+    // Payment 조회 시 연관된 Order를 fetch join 으로 함께 로딩 (N+1 방지)
+    @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.id = :paymentId")
+    Optional<Payment> findByIdWithOrder(@Param("paymentId") Long paymentId);
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/repository/RefundRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/repository/RefundRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.paymentsystem.domain.payment.repository;
+
+import com.sparta.paymentsystem.domain.payment.entity.Refund;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentCommandService.java
@@ -4,6 +4,7 @@ import com.sparta.paymentsystem.domain.order.entity.Order;
 import com.sparta.paymentsystem.domain.order.entity.OrderItem;
 
 import com.sparta.paymentsystem.domain.order.service.OrderService;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentCancelResponse;
 import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmResponse;
 import com.sparta.paymentsystem.domain.payment.entity.Payment;
 import com.sparta.paymentsystem.domain.product.entity.Product;
@@ -11,6 +12,8 @@ import com.sparta.paymentsystem.domain.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 /**
  * 결제 승인/실패 시 여러 도메인(결제, 주문, 상품)을 한 트랜잭션으로 묶어 처리하는 서비스
@@ -28,6 +31,7 @@ public class PaymentCommandService {
     private final PaymentService paymentService;
     private final OrderService orderService;
     private final ProductService productService;
+    private final RefundService refundService;
 
     /**
      * 결제 실패 처리
@@ -79,6 +83,43 @@ public class PaymentCommandService {
                 payment.getStatus().name(),
                 order.getStatus().name(),
                 "결제가 완료되었습니다."
+        );
+    }
+
+    /**
+     * 결제 전액 취소 처리
+     *
+     * 흐름:
+     *   1) paymentId 로 결제 + 주문을 함께 조회 (fetch join)
+     *   2) 결제 상태 → CANCELED
+     *   3) 주문 상태 → CANCELED
+     *   4) 주문 상품들의 재고 복구
+     *   5) 환불 이력(Refund) 생성 — 언제, 왜, 얼마를 돌려줬는지 기록
+     *   6) 클라이언트에 내려줄 응답 DTO 반환
+     *
+     * 취소는 단순히 상태만 바꾸는 게 아니라 "환불 이력"을 남겨야 한다.
+     * 고객 CS 대응, 정산, 분쟁 대응을 위해 누가/언제/왜 취소했는지 추적 가능해야 하기 때문이다.
+     * 이 모든 단계는 @Transactional 로 묶여 하나라도 실패하면 전부 롤백된다.
+     *
+     */
+    @Transactional
+    public PaymentCancelResponse cancelPaymentAndOrder(Long paymentId, String cancelReason) {
+        Payment payment = paymentService.findByIdWithOrder(paymentId);
+        Order order = payment.getOrder();
+
+        paymentService.cancelPayment(payment);
+        orderService.cancelOrder(order);
+        restoreStock(order);
+
+        refundService.createRefund(payment, cancelReason, LocalDateTime.now());
+
+        return new PaymentCancelResponse(
+                paymentId,
+                order.getId(),
+                payment.getPortonePaymentId(),
+                payment.getStatus().name(),
+                order.getStatus().name(),
+                "결제가 취소되었습니다"
         );
     }
 

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
@@ -62,4 +62,16 @@ public class PaymentService {
     public void failPayment(Payment payment) {
         payment.markAsFailed();
     }
+
+    // 결제 상태 변경 (CANCELLED)
+    @Transactional
+    public void cancelPayment(Payment payment) {
+        payment.markAsCancelled();
+    }
+
+    // 결제 정보와 연관된 주문 정보를 paymentId 기반으로 조회
+    public Payment findByIdWithOrder(Long paymentId) {
+        return paymentRepository.findByIdWithOrder(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/service/RefundService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/service/RefundService.java
@@ -1,0 +1,24 @@
+package com.sparta.paymentsystem.domain.payment.service;
+
+import com.sparta.paymentsystem.domain.payment.entity.Payment;
+import com.sparta.paymentsystem.domain.payment.entity.Refund;
+import com.sparta.paymentsystem.domain.payment.repository.RefundRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class RefundService {
+
+    private final RefundRepository refundRepository;
+
+    @Transactional
+    public void createRefund(Payment payment, String cancelReason, LocalDateTime refundedAt) {
+        Refund refund = new Refund(payment, cancelReason, refundedAt);
+        refundRepository.save(refund);
+    }
+
+}

--- a/src/test/http/payment-cancel.http
+++ b/src/test/http/payment-cancel.http
@@ -1,0 +1,110 @@
+### 사전 준비: 로그인 (토큰 발급)
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "sparta@nbcamp.com",
+  "password": "sparta1234"
+}
+
+> {%
+    client.global.set("token", response.body.data.token);
+%}
+
+###
+
+### 사전 준비: 취소 전 상품 재고 확인
+GET http://localhost:8080/api/products/1
+Authorization: Bearer {{token}}
+
+> {%
+    client.global.set("stockBefore", response.body.data.stock);
+    client.log("취소 전 재고: " + response.body.data.stock);
+%}
+
+###
+
+### TC-1. 결제 취소 정상 처리
+# 사전 조건: paymentId=1이 PAID 상태여야 함 (order-checkout → payment-confirm 완료 후 실행)
+# 기대: 200 OK + paymentStatus: CANCELLED, orderStatus: CANCELLED, message 반환
+POST http://localhost:8080/api/payments/1/cancel
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "reason": "단순 변심"
+}
+
+> {%
+    client.test("응답 코드 200", function () {
+        client.assert(response.status === 200, "Expected 200 OK");
+    });
+    client.test("paymentStatus CANCELLED", function () {
+        client.assert(response.body.data.paymentStatus === "CANCELLED", "paymentStatus should be CANCELLED");
+    });
+    client.test("orderStatus CANCELLED", function () {
+        client.assert(response.body.data.orderStatus === "CANCELLED", "orderStatus should be CANCELLED");
+    });
+    client.test("orderId 존재", function () {
+        client.assert(response.body.data.orderId != null, "orderId should not be null");
+    });
+    client.test("message 존재", function () {
+        client.assert(response.body.data.message != null, "message should not be null");
+    });
+%}
+
+###
+
+### TC-2. 중복 취소 시도
+# TC-1 이후 동일 요청 재전송
+# 기대: 400 Bad Request (PAID가 아니므로 상태 선검증에서 거부)
+POST http://localhost:8080/api/payments/1/cancel
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "reason": "단순 변심"
+}
+
+> {%
+    client.test("응답 코드 400", function () {
+        client.assert(response.status === 400, "Expected 400 Bad Request");
+    });
+%}
+
+###
+
+### TC-3. 존재하지 않는 결제 취소
+# 기대: 404 Not Found
+POST http://localhost:8080/api/payments/999/cancel
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "reason": "테스트"
+}
+
+> {%
+    client.test("응답 코드 404", function () {
+        client.assert(response.status === 404, "Expected 404 Not Found");
+    });
+%}
+
+###
+
+### TC-4. 재고 원복 검증
+# TC-1 이후 실행 — 취소 후 재고가 주문 수량만큼 복구되었는지 확인
+GET http://localhost:8080/api/products/1
+Authorization: Bearer {{token}}
+
+> {%
+    client.test("응답 코드 200", function () {
+        client.assert(response.status === 200, "Expected 200 OK");
+    });
+    client.test("재고 원복 확인", function () {
+        var stockAfter = response.body.data.stock;
+        var stockBefore = client.global.get("stockBefore");
+        client.log("취소 전 재고: " + stockBefore + ", 취소 후 재고: " + stockAfter);
+        client.assert(stockAfter > stockBefore, "Stock should be restored after cancellation");
+    });
+%}


### PR DESCRIPTION
### 변경 사항

- Refund 엔티티 및 RefundRepository & RefundService 생성
- PaymentCancelRequest, PaymentCancelResponse DTO
- PaymentService.cancelPayment & Payment.markAsCancelled & PaymentRepository.findByIdWithOrder 구현
- PaymentCommandService.cancelPaymentAndOrder 구현
- PaymentFacade.cancelPayment 구현
- PaymentController에 `POST /api/payments/{id}/cancel` 엔드포인트 추가

### 테스트

- [x]  수동 테스트 완료 (Postman / 브라우저)
    - 결제 완료 후 취소 요청 → 200 OK, 상태 CANCELLED 확인
    - 이미 취소된 결제 재취소 시도 → 에러 응답 확인
    - 존재하지 않는 결제 취소 → 에러 응답 확인
    - 취소 전후 stock 비교
- [x]  기존 기능 영향 없음 확인

### 스크린샷

(Postman 취소 요청/응답 캡처)

### 관련 Issue

- Closes #21
